### PR TITLE
Add Crockoach DB configuration

### DIFF
--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -2,6 +2,7 @@
 """Base settings to build other settings files upon."""
 
 import ssl
+import sys
 from pathlib import Path
 
 import environ
@@ -48,9 +49,15 @@ LOCALE_PATHS = [str(BASE_DIR / "locale")]
 # DATABASES
 # ------------------------------------------------------------------------------
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
+
+
 DATABASES = {"default": env.db("DATABASE_URL")}
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
-DATABASES["default"]["ENGINE"] = "django_cockroachdb"
+
+# Use Postgres for testing, CockroachDB for production
+if "test" not in sys.argv and "pytest" not in sys.modules:
+    DATABASES["default"]["ENGINE"] = "django_cockroachdb"
+
 # https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DEFAULT_AUTO_FIELD
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -50,6 +50,7 @@ LOCALE_PATHS = [str(BASE_DIR / "locale")]
 # https://docs.djangoproject.com/en/dev/ref/settings/#databases
 DATABASES = {"default": env.db("DATABASE_URL")}
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
+DATABASES["default"]["ENGINE"] = "django_cockroachdb"
 # https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DEFAULT_AUTO_FIELD
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -33,3 +33,5 @@ django-solo==2.4.0  # https://github.com/lazybird/django-solo
 
 #OpenAI
 openai==1.102.0  # https://pypi.org/project/openai/
+
+django-cockroachdb==5.2  # https://github.com/cockroachdb/django-cockroachdb

--- a/settings/admin.py
+++ b/settings/admin.py
@@ -34,15 +34,6 @@ class OpenAISettingAdmin(SingletonModelAdmin, ModelAdmin):
 
     actions_detail = ["check_connection"]
 
-    def has_add_permission(self, request):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False
-
     @action(
         description=_("Check Connection"),
         url_path="check-connection",
@@ -80,12 +71,3 @@ class CoreAPISettingAdmin(SingletonModelAdmin, ModelAdmin):
         ),
     )
     readonly_fields = ("created_at", "updated_at")
-
-    def has_add_permission(self, request):
-        return False
-
-    def has_change_permission(self, request, obj=None):
-        return False
-
-    def has_delete_permission(self, request, obj=None):
-        return False


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - None
- Bug Fixes
  - Restored default Django admin permissions for settings entries, re-enabling add/change/delete where roles permit; no other admin actions changed.
- Chores
  - Configured CockroachDB as the default database backend in non-test runs.
  - Added the CockroachDB integration dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->