### PR TITLE
Update Docker Compose Production

### DIFF
--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -1,3 +1,7 @@
+# Check this PR for postgres and redis being
+# https://github.com/animemoeus/instarchiver-backend/pull/58
+
+
 volumes:
   instarchiver_production_postgres_data: {}
   instarchiver_production_postgres_data_backups: {}


### PR DESCRIPTION
This pull request comments out the `postgres` and `redis` service definitions in the `docker-compose.production.yml` file. These changes effectively disable the built-in database and cache services in the production Docker Compose configuration, likely in preparation for using external or managed services instead of local containers.

Service configuration changes:

* Commented out the `depends_on` entries for `postgres` and `redis` in the `django` service, so it no longer waits for these services to be available.
* Commented out the entire `postgres` service block, removing the built-in database container from the production setup.
* Commented out the entire `redis` service block, removing the built-in cache container from the production setup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production deployment configuration to streamline the service setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->