### PR TITLE
Update API Docs URLs

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -25,7 +25,7 @@ if settings.DEBUG:
 urlpatterns += [
     path("schema/", SpectacularAPIView.as_view(), name="api-schema"),
     path(
-        "",
+        "api/docs/",
         SpectacularSwaggerView.as_view(url_name="api-schema"),
         name="api-docs",
     ),


### PR DESCRIPTION
This pull request updates the API documentation route in the `config/urls.py` file to improve clarity and organization.

Routing changes:

* Changed the path for the Swagger API documentation from the root (`""`) to `api/docs/` for better separation and discoverability of API docs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * API documentation is now accessible at an updated URL path for easier access to endpoint reference and Swagger UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->