### PR TITLE
Update Home Page Routing

### DIFF
--- a/config/urls.py
+++ b/config/urls.py
@@ -5,10 +5,12 @@ from django.contrib.staticfiles.urls import staticfiles_urlpatterns
 from django.urls import include
 from django.urls import path
 from django.views import defaults as default_views
+from django.views.generic import RedirectView
 from drf_spectacular.views import SpectacularAPIView
 from drf_spectacular.views import SpectacularSwaggerView
 
 urlpatterns = [
+    path("", RedirectView.as_view(url="/api/docs/", permanent=False)),
     # Django Admin, use {% url 'admin:index' %}
     path(settings.ADMIN_URL, admin.site.urls),
     # Your stuff: custom urls includes go here


### PR DESCRIPTION
This pull request introduces a small update to the application's URL routing. The main change is the addition of a redirect from the root URL to the API documentation, improving the developer experience and making documentation more discoverable.

* Routing improvement:
  * Added a redirect from the root URL (`"/"`) to the API documentation at `"/api/docs/"` using Django's `RedirectView`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Root URL now redirects to the API documentation page.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->