### PR TITLE
Add autoscale option to celery beat command

### DIFF
--- a/compose/production/django/celery/beat/start
+++ b/compose/production/django/celery/beat/start
@@ -5,4 +5,4 @@ set -o pipefail
 set -o nounset
 
 
-exec celery -A config.celery_app beat -l INFO
+exec celery -A config.celery_app beat -l INFO --autoscale=8,2


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified celery beat startup configuration to enable dynamic worker process scaling between a minimum of 2 and maximum of 8 processes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->