### PR TITLE
Revert "Add autoscale option to celery beat command"

### DIFF
--- a/compose/production/django/celery/beat/start
+++ b/compose/production/django/celery/beat/start
@@ -5,4 +5,4 @@ set -o pipefail
 set -o nounset
 
 
-exec celery -A config.celery_app beat -l INFO --autoscale=8,2
+exec celery -A config.celery_app beat -l INFO


### PR DESCRIPTION
Reverts instarchiver/instarchiver-backend#191

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified background job scheduler configuration by removing dynamic worker autoscaling. The service now operates with a static worker setup instead of automatically scaling between minimum and maximum instances, providing more predictable resource allocation and streamlined operational management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->