### PR TITLE
Revert "Update Debian Mirror"

### DIFF
--- a/compose/production/django/Dockerfile
+++ b/compose/production/django/Dockerfile
@@ -7,9 +7,6 @@ FROM python AS python-build-stage
 
 ARG BUILD_ENVIRONMENT=production
 
-# Use faster Debian mirror (CDN)
-RUN sed -i 's/deb.debian.org/cloudfront.debian.net/g' /etc/apt/sources.list.d/debian.sources
-
 # Install apt packages
 RUN apt-get update && apt-get install --no-install-recommends -y \
   # dependencies for building Python packages
@@ -41,8 +38,6 @@ WORKDIR ${APP_HOME}
 RUN addgroup --system django \
   && adduser --system --ingroup django django
 
-# Use faster Debian mirror (CDN)
-RUN sed -i 's/deb.debian.org/cloudfront.debian.net/g' /etc/apt/sources.list.d/debian.sources
 
 # Install required system dependencies
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/compose/production/postgres/Dockerfile
+++ b/compose/production/postgres/Dockerfile
@@ -1,8 +1,5 @@
 FROM docker.io/postgres:17
 
-# Use faster Debian mirror (CDN)
-RUN sed -i 's/deb.debian.org/cloudfront.debian.net/g' /etc/apt/sources.list.d/debian.sources
-
 RUN apt-get update && apt-get install -y postgresql-17-pgvector \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Reverts instarchiver/instarchiver-backend#200

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Django production Docker configuration to use default Debian package mirrors
  * Modified PostgreSQL production Docker configuration, including reorganized maintenance script handling for improved accessibility

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->