### PR TITLE
Build(deps): Remove Tailscale setup from deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -9,17 +9,10 @@ jobs:
   Deploying:
     runs-on: ubuntu-latest
     steps:
-      - name: Setup Tailscale
-        uses: tailscale/github-action@v4
-        with:
-          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
-          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
-          tags: tag:ci
-
       - name: Executing Remote SSH Commands Using Password
         uses: appleboy/ssh-action@master
         with:
-          host: ${{ secrets.SSH_HOST_TAILSCALE }}
+          host: ${{ secrets.SSH_HOST }}
           username: ${{ secrets.SSH_USERNAME}}
           password: ${{ secrets.SSH_PASSWORD}}
           port: 22


### PR DESCRIPTION
This pull request simplifies the deployment workflow by removing the use of Tailscale for SSH connections and switching to a direct SSH host. The main change is to streamline the deployment process and reduce dependencies.

Deployment workflow simplification:

* Removed the Tailscale setup step and related configuration from the deployment job in `.github/workflows/deployment.yml`.
* Updated the SSH action to use the standard SSH host secret (`SSH_HOST`) instead of the Tailscale-specific host secret (`SSH_HOST_TAILSCALE`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated deployment configuration and process for improved reliability.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->