### PR TITLE
Update Worklfow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -92,6 +92,20 @@ jobs:
             exit 1
           fi
 
+          # Detect if owner is an organization or personal account
+          echo "Detecting account type for ${OWNER}..."
+          OWNER_TYPE=$(gh api "/users/${OWNER}" --jq '.type')
+
+          if [ "$OWNER_TYPE" = "Organization" ]; then
+            PACKAGES_ENDPOINT="/orgs/${OWNER}/packages"
+            PACKAGE_ENDPOINT_PREFIX="/orgs/${OWNER}"
+            echo "Detected organization account: ${OWNER}"
+          else
+            PACKAGES_ENDPOINT="/user/packages"
+            PACKAGE_ENDPOINT_PREFIX="/user"
+            echo "Detected personal account: ${OWNER}"
+          fi
+
           echo "Retrieving container packages for ${OWNER}/${REPO_NAME}..."
 
           # Fetch container packages (limited to first 100)
@@ -100,7 +114,7 @@ jobs:
           PACKAGE_NAMES=$(gh api \
             -H "Accept: application/vnd.github+json" \
             -H "X-GitHub-Api-Version: 2022-11-28" \
-            "/orgs/${OWNER}/packages?package_type=container&per_page=100" \
+            "${PACKAGES_ENDPOINT}?package_type=container&per_page=100" \
             --jq '.[].name')
 
           if [ -z "${PACKAGE_NAMES}" ]; then
@@ -125,7 +139,7 @@ jobs:
                   --method PATCH \
                   -H "Accept: application/vnd.github+json" \
                   -H "X-GitHub-Api-Version: 2022-11-28" \
-                  "/orgs/${OWNER}/packages/container/${PACKAGE_PATH_ENCODED}" \
+                  "${PACKAGE_ENDPOINT_PREFIX}/packages/container/${PACKAGE_PATH_ENCODED}" \
                   -f visibility="public" 2>&1); then
                   echo "Could not set ${FULL_NAME} to public (may already be public or not editable). Details:"
                   echo "${OUTPUT}"


### PR DESCRIPTION
This pull request improves the deployment workflow by making it compatible with both organization and personal GitHub accounts when managing container packages. The workflow now dynamically detects the account type and uses the appropriate API endpoints.

**GitHub API endpoint handling:**

* Added logic to detect if `OWNER` is an organization or a personal account, setting the correct API endpoints for each case.
* Updated the API call for retrieving container package names to use the dynamically selected endpoint based on account type.
* Updated the API call for setting package visibility to use the appropriate endpoint prefix for organizations or users.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * GitHub Actions deployment workflow now intelligently detects and supports both personal and organization GitHub accounts when managing container package visibility.

* **Chores**
  * Improved deployment automation with enhanced runtime account-type detection that dynamically adjusts API endpoints and package management operations based on account type, while preserving error handling and pagination behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->