### PR TITLE
Revert "Celery Worder Gevent"

### DIFF
--- a/compose/production/django/celery/worker/start
+++ b/compose/production/django/celery/worker/start
@@ -5,7 +5,4 @@ set -o pipefail
 set -o nounset
 
 
-exec celery -A config.celery_app worker \
-    -l INFO \
-    --pool=gevent \
-    --concurrency=50
+exec celery -A config.celery_app worker -l INFO

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -5,7 +5,6 @@ whitenoise==6.12.0  # https://github.com/evansd/whitenoise
 redis==7.4.0  # https://github.com/redis/redis-py
 hiredis==3.3.1  # https://github.com/redis/hiredis-py
 celery==5.6.3  # pyup: < 6.0  # https://github.com/celery/celery
-gevent==25.4.1  # https://github.com/gevent/gevent
 django-celery-beat==2.9.0  # https://github.com/celery/django-celery-beat
 flower==2.0.1  # https://github.com/mher/flower
 uvicorn[standard]==0.46.0  # https://github.com/encode/uvicorn


### PR DESCRIPTION
Reverts instarchiver/instarchiver-backend#555

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Streamlined Celery worker startup by removing the gevent dependency and simplifying configuration parameters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/instarchiver/instarchiver-backend/pull/559?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->