### PR TITLE
OTEL V2

### DIFF
--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -6,4 +6,4 @@ set -o nounset
 
 
 python manage.py migrate
-exec uvicorn config.asgi:application --host 0.0.0.0
+exec uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'

--- a/compose/local/django/start
+++ b/compose/local/django/start
@@ -6,4 +6,4 @@ set -o nounset
 
 
 python manage.py migrate
-exec uvicorn config.asgi:application --host 0.0.0.0 --reload --reload-include '*.html'
+exec uvicorn config.asgi:application --host 0.0.0.0

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -7,4 +7,4 @@ set -o nounset
 
 python /app/manage.py collectstatic --noinput
 
-exec opentelemetry-instrument /usr/local/bin/gunicorn config.asgi --bind 0.0.0.0:5000 --chdir=/app -k uvicorn_worker.UvicornWorker --workers 4
+exec /usr/local/bin/gunicorn config.asgi:application --bind 0.0.0.0:5000 --chdir=/app -k uvicorn_worker.UvicornWorker --workers 4

--- a/config/asgi.py
+++ b/config/asgi.py
@@ -12,8 +12,6 @@ import os
 import sys
 from pathlib import Path
 
-from django.core.asgi import get_asgi_application
-
 # This allows easy placement of apps within the interior
 # core directory.
 BASE_DIR = Path(__file__).resolve(strict=True).parent.parent
@@ -21,6 +19,23 @@ sys.path.append(str(BASE_DIR / "core"))
 
 # If DJANGO_SETTINGS_MODULE is unset, default to the local settings
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "config.settings.local")
+
+# Initialize OpenTelemetry per-worker (runs after Gunicorn fork, safe for multi-worker).
+# Conditional on OTEL_EXPORTER_OTLP_ENDPOINT so local dev without the env var is unaffected.  # noqa: E501
+if os.environ.get("OTEL_EXPORTER_OTLP_ENDPOINT"):
+    from opentelemetry import trace
+    from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
+    from opentelemetry.instrumentation.django import DjangoInstrumentor
+    from opentelemetry.sdk.resources import Resource
+    from opentelemetry.sdk.trace import TracerProvider
+    from opentelemetry.sdk.trace.export import BatchSpanProcessor
+
+    _provider = TracerProvider(resource=Resource.create())
+    _provider.add_span_processor(BatchSpanProcessor(OTLPSpanExporter()))
+    trace.set_tracer_provider(_provider)
+    DjangoInstrumentor().instrument()
+
+from django.core.asgi import get_asgi_application  # noqa: E402
 
 # This application object is used by any ASGI server configured to use this file.
 django_application = get_asgi_application()


### PR DESCRIPTION
This pull request updates the ASGI application setup and deployment scripts to improve OpenTelemetry integration and streamline local development. The most important changes are grouped below:

**OpenTelemetry Integration Improvements:**

* [`config/asgi.py`](diffhunk://#diff-e6351d76c95e05b7cf6c87dc62446cff8b8116141018417e22cbaddd3bcad742R23-R39): OpenTelemetry initialization is now performed directly in the ASGI application, conditionally enabled only when the `OTEL_EXPORTER_OTLP_ENDPOINT` environment variable is set. This ensures tracing is configured per worker after Gunicorn forks, making it safe for multi-worker setups and avoiding issues in local development.
* [`compose/production/django/start`](diffhunk://#diff-e3622785da549304c4304fc1faae833ce6d272cea53bfad382ca294df1f94b74L10-R10): The `opentelemetry-instrument` wrapper was removed from the Gunicorn startup command, as instrumentation is now handled inside the ASGI application itself.

**Codebase Cleanup and Local Development:**

* [`config/asgi.py`](diffhunk://#diff-e6351d76c95e05b7cf6c87dc62446cff8b8116141018417e22cbaddd3bcad742L15-L16): The import of `get_asgi_application` was moved to after OpenTelemetry setup to ensure correct initialization order.
* [`compose/local/django/start`](diffhunk://#diff-7c65ec2d8ae59f4c1de49aeb895b0b92345064667204319392657ef7a3ed411dL9-R9): The `--reload` and `--reload-include` options were removed from the `uvicorn` command, streamlining the local development startup process.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

**Refactor**
- Reorganized application startup process: moved OpenTelemetry observability tracing initialization from the startup script to the ASGI application configuration level. Tracing automatically activates when observability endpoints are configured, with enhanced support for multi-worker production environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->