### PR TITLE
Improve Resource Usage For Preview Deployment

### DIFF
--- a/config/settings/local.py
+++ b/config/settings/local.py
@@ -74,5 +74,7 @@ if env("USE_DOCKER") == "yes":
 
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-eager-propagates
 CELERY_TASK_EAGER_PROPAGATES = True
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#task-always-eager
+CELERY_TASK_ALWAYS_EAGER = env.bool("CELERY_TASK_ALWAYS_EAGER", default=False)
 # Your stuff...
 # ------------------------------------------------------------------------------

--- a/docker-compose.preview.yml
+++ b/docker-compose.preview.yml
@@ -1,10 +1,11 @@
 volumes:
   postgres_data: {}
-  redis_data: {}
 
 services:
-  django: &django
+  django:
     image: ghcr.io/${IMAGE_REPO}/django:pr-${PR_NUMBER}
+    mem_limit: 512m
+    cpus: 0.75
     networks:
       - preview-internal
       - traefik
@@ -23,17 +24,19 @@ services:
       - ${SHARED_ENV_DIR}/.django
       - ${SHARED_ENV_DIR}/.postgres
       - .env
+    environment:
+      CELERY_TASK_ALWAYS_EAGER: "True"
     command: /start
     depends_on:
       postgres:
         condition: service_healthy
-      redis:
-        condition: service_started
       mailpit:
         condition: service_started
 
   postgres:
     image: ghcr.io/${IMAGE_REPO}/postgres:pr-${PR_NUMBER}
+    mem_limit: 256m
+    cpus: 0.25
     networks:
       - preview-internal
     volumes:
@@ -47,39 +50,12 @@ services:
       timeout: 5s
       retries: 10
 
-  redis:
-    image: docker.io/redis:6
-    networks:
-      - preview-internal
-    volumes:
-      - redis_data:/data
-
   mailpit:
     image: docker.io/axllent/mailpit:latest
+    mem_limit: 64m
+    cpus: 0.1
     networks:
       - preview-internal
-
-  celeryworker:
-    <<: *django
-    networks:
-      - preview-internal
-    labels: {}
-    command: /start-celeryworker
-    depends_on:
-      - redis
-      - postgres
-      - mailpit
-
-  celerybeat:
-    <<: *django
-    networks:
-      - preview-internal
-    labels: {}
-    command: /start-celerybeat
-    depends_on:
-      - redis
-      - postgres
-      - mailpit
 
 networks:
   preview-internal:


### PR DESCRIPTION
# Description

This pull request simplifies the Docker Compose setup for the preview environment by removing the separate Celery worker and Redis services, consolidating background task execution into the main Django container, and optimizing resource allocation for each service. It also introduces configuration changes to ensure Celery tasks run synchronously in this environment.

**Docker Compose service consolidation and resource optimization:**

* Removed the `redis` service and associated `redis_data` volume, as well as the dedicated `celeryworker` and `celerybeat` services, consolidating all background task execution into the main `django` container. [[1]](diffhunk://#diff-955113a4df5f358519a09ec91d247b56f603f605c63dcc755cdb91b826e17816L3-R8) [[2]](diffhunk://#diff-955113a4df5f358519a09ec91d247b56f603f605c63dcc755cdb91b826e17816L50-L83)
* Set resource limits for the `django`, `postgres`, and `mailpit` services by specifying `mem_limit` and `cpus` for each, improving resource usage and predictability in the preview environment. [[1]](diffhunk://#diff-955113a4df5f358519a09ec91d247b56f603f605c63dcc755cdb91b826e17816L3-R8) [[2]](diffhunk://#diff-955113a4df5f358519a09ec91d247b56f603f605c63dcc755cdb91b826e17816R27-R39) [[3]](diffhunk://#diff-955113a4df5f358519a09ec91d247b56f603f605c63dcc755cdb91b826e17816L50-L83)

**Celery configuration changes:**

* Configured the preview environment so that Celery tasks always run eagerly (synchronously) by setting the `CELERY_TASK_ALWAYS_EAGER` environment variable to `"True"` for the `django` service and adding the corresponding setting in `config/settings/local.py`. This ensures background tasks are executed immediately and do not require a separate worker or message broker. [[1]](diffhunk://#diff-d699d1610cb06e78bfedaca679279700e61d4f448aa6e7cfe83f5d044a0968d3R77-R78) [[2]](diffhunk://#diff-955113a4df5f358519a09ec91d247b56f603f605c63dcc755cdb91b826e17816R27-R39)