### PR TITLE
PgBouncer Improvement 

### DIFF
--- a/.envs/.local/.postgres
+++ b/.envs/.local/.postgres
@@ -5,3 +5,8 @@ POSTGRES_PORT=5432
 POSTGRES_DB=core
 POSTGRES_USER=vnBBpYtVKPRsqHnKsQjZGPPUBZcLpZam
 POSTGRES_PASSWORD=p9r7XZd0W2HlKsynjsv5yK8yy0iJ1fsmHJjkGB92j33bUfQfI8oCyQZv3Ay0LfVW
+
+# PGBOUNCER
+# ------------------------------------------------------------------------------
+DB_USER=vnBBpYtVKPRsqHnKsQjZGPPUBZcLpZam
+DB_PASSWORD=p9r7XZd0W2HlKsynjsv5yK8yy0iJ1fsmHJjkGB92j33bUfQfI8oCyQZv3Ay0LfVW

--- a/.envs/.local/.postgres
+++ b/.envs/.local/.postgres
@@ -1,6 +1,6 @@
 # PostgreSQL
 # ------------------------------------------------------------------------------
-POSTGRES_HOST=postgres
+POSTGRES_HOST=pgbouncer
 POSTGRES_PORT=5432
 POSTGRES_DB=core
 POSTGRES_USER=vnBBpYtVKPRsqHnKsQjZGPPUBZcLpZam

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -52,6 +52,7 @@ LOCALE_PATHS = [str(BASE_DIR / "locale")]
 DATABASES = {"default": env.db("DATABASE_URL")}
 DATABASES["default"]["ENGINE"] = "django_prometheus.db.backends.postgresql"
 DATABASES["default"]["ATOMIC_REQUESTS"] = True
+DATABASES["default"]["DISABLE_SERVER_SIDE_CURSORS"] = True
 # https://docs.djangoproject.com/en/stable/ref/settings/#std:setting-DEFAULT_AUTO_FIELD
 DEFAULT_AUTO_FIELD = "django.db.models.BigAutoField"
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -13,7 +13,7 @@ services:
     volumes:
       - instarchiver_production_django_media:/app/core/media
     depends_on:
-      - postgres
+      - pgbouncer
       - redis
     env_file:
       - ./.envs/.production/.django
@@ -29,6 +29,23 @@ services:
       - instarchiver_production_postgres_data_backups:/backups
     env_file:
       - ./.envs/.production/.postgres
+
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    container_name: instarchiver_production_pgbouncer
+    env_file:
+      - ./.envs/.production/.postgres
+    environment:
+      - DB_HOST=postgres
+      - AUTH_TYPE=scram-sha-256
+      - POOL_MODE=transaction
+    depends_on:
+      - postgres
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-h', 'localhost']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: docker.io/redis:6

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -11,9 +11,14 @@ services:
     image: instarchiver_local_django
     container_name: instarchiver_local_django
     depends_on:
-      - postgres
-      - redis
-      - mailpit
+      postgres:
+        condition: service_started
+      pgbouncer:
+        condition: service_healthy
+      redis:
+        condition: service_started
+      mailpit:
+        condition: service_started
     volumes:
       - .:/app:z
     env_file:
@@ -51,6 +56,9 @@ services:
       - "54321:5432"
     healthcheck:
       test: ['CMD', 'pg_isready', '-h', 'localhost']
+      interval: 5s
+      timeout: 5s
+      retries: 5
     depends_on:
       - postgres
 
@@ -71,9 +79,14 @@ services:
     image: instarchiver_local_celeryworker
     container_name: instarchiver_local_celeryworker
     depends_on:
-      - redis
-      - postgres
-      - mailpit
+      redis:
+        condition: service_started
+      postgres:
+        condition: service_started
+      pgbouncer:
+        condition: service_healthy
+      mailpit:
+        condition: service_started
     ports: []
     command: /start-celeryworker
 
@@ -82,9 +95,14 @@ services:
     image: instarchiver_local_celerybeat
     container_name: instarchiver_local_celerybeat
     depends_on:
-      - redis
-      - postgres
-      - mailpit
+      redis:
+        condition: service_started
+      postgres:
+        condition: service_started
+      pgbouncer:
+        condition: service_healthy
+      mailpit:
+        condition: service_started
     ports: []
     command: /start-celerybeat
 

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -34,8 +34,25 @@ services:
       - instarchiver_local_postgres_data_backups:/backups
     env_file:
       - ./.envs/.local/.postgres
+    # ports:
+    #   - '54321:5432'
+
+  pgbouncer:
+    container_name: pgbouncer
+    ### build from source
+    image: edoburu/pgbouncer:latest
+    env_file:
+      - ./.envs/.local/.postgres
+    environment:
+      - DB_HOST=postgres
+      - AUTH_TYPE=scram-sha-256
+      - POOL_MODE=transaction
     ports:
-      - '54321:5432'
+      - "54321:5432"
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-h', 'localhost']
+    depends_on:
+      - postgres
 
   mailpit:
     image: docker.io/axllent/mailpit:latest

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -17,7 +17,7 @@ services:
     volumes:
       - instarchiver_production_django_media:/app/core/media
     depends_on:
-      - postgres
+      - pgbouncer
       - redis
     env_file:
       - ./.envs/.production/.django
@@ -36,6 +36,23 @@ services:
       - instarchiver_production_postgres_data_backups:/backups
     env_file:
       - ./.envs/.production/.postgres
+
+  pgbouncer:
+    image: edoburu/pgbouncer:latest
+    container_name: instarchiver_production_pgbouncer
+    env_file:
+      - ./.envs/.production/.postgres
+    environment:
+      - DB_HOST=postgres
+      - AUTH_TYPE=scram-sha-256
+      - POOL_MODE=transaction
+    depends_on:
+      - postgres
+    healthcheck:
+      test: ['CMD', 'pg_isready', '-h', 'localhost']
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     image: docker.io/redis:6


### PR DESCRIPTION
This pull request introduces PgBouncer as a connection pooler for PostgreSQL in both local and production environments, updating relevant service dependencies and configuration to route database connections through PgBouncer. It also includes a Django setting to disable server-side cursors, which is recommended when using PgBouncer.

**PgBouncer Integration and Configuration:**

* Added `pgbouncer` service to both `docker-compose.local.yml` and `docker-compose.production.yml`, configuring it to connect to the existing `postgres` service and exposing port `54321` for local development. [[1]](diffhunk://#diff-ae586547cbd27ba91859c4ac87402a4e4b13957d883dc26161dc5cb1d32f2883R37-R55) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R40-R56)
* Updated Django and other service dependencies to depend on `pgbouncer` instead of directly on `postgres`, ensuring all database traffic passes through PgBouncer. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0L16-R16) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8L20-R20)
* Changed the `POSTGRES_HOST` in `.envs/.local/.postgres` to `pgbouncer` and added `DB_USER` and `DB_PASSWORD` environment variables for PgBouncer authentication.

**Django Database Settings:**

* Set `DISABLE_SERVER_SIDE_CURSORS = True` in `config/settings/base.py` to ensure compatibility with PgBouncer in transaction pooling mode.