### PR TITLE
Add restart policy to all services in docker-compose files

### DIFF
--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -9,6 +9,7 @@ volumes:
 services:
   django: &django
     image: ghcr.io/instarchiver/instarchiver-backend/django:latest
+    restart: unless-stopped
     mem_limit: 1g
     volumes:
       - instarchiver_production_django_media:/app/core/media
@@ -22,6 +23,7 @@ services:
 
   postgres:
     image: ghcr.io/instarchiver/instarchiver-backend/postgres:latest
+    restart: unless-stopped
     ports:
       - 100.73.60.108:65432:5432
     volumes:
@@ -33,6 +35,7 @@ services:
   pgbouncer:
     image: edoburu/pgbouncer:latest
     container_name: instarchiver_production_pgbouncer
+    restart: unless-stopped
     env_file:
       - ./.envs/.production/.postgres
     environment:
@@ -49,6 +52,7 @@ services:
 
   redis:
     image: docker.io/redis:6
+    restart: unless-stopped
     volumes:
       - instarchiver_production_redis_data:/data
     ports:
@@ -72,6 +76,7 @@ services:
 
   nginx:
     image: ghcr.io/instarchiver/instarchiver-backend/nginx:latest
+    restart: unless-stopped
     depends_on:
       - django
     volumes:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -13,6 +13,7 @@ services:
       dockerfile: ./compose/production/django/Dockerfile
 
     image: instarchiver_production_django
+    restart: unless-stopped
     mem_limit: 1g
     volumes:
       - instarchiver_production_django_media:/app/core/media
@@ -29,6 +30,7 @@ services:
       context: .
       dockerfile: ./compose/production/postgres/Dockerfile
     image: instarchiver_production_postgres
+    restart: unless-stopped
     ports:
       - 100.73.60.108:65432:5432
     volumes:
@@ -40,6 +42,7 @@ services:
   pgbouncer:
     image: edoburu/pgbouncer:latest
     container_name: instarchiver_production_pgbouncer
+    restart: unless-stopped
     env_file:
       - ./.envs/.production/.postgres
     environment:
@@ -56,6 +59,7 @@ services:
 
   redis:
     image: docker.io/redis:6
+    restart: unless-stopped
     volumes:
       - instarchiver_production_redis_data:/data
     ports:
@@ -82,6 +86,7 @@ services:
       context: .
       dockerfile: ./compose/production/nginx/Dockerfile
     image: instarchiver_production_nginx
+    restart: unless-stopped
     depends_on:
       - django
     volumes:


### PR DESCRIPTION
## Description

This pull request updates the Docker Compose configuration files to improve service reliability in production and GHCR deployments. The main change is the addition of the `restart: unless-stopped` policy to all major services, ensuring that containers automatically restart if they exit unexpectedly unless explicitly stopped.

**Docker Compose reliability improvements:**

* Added `restart: unless-stopped` to the `django` service in both `docker-compose.ghcr.yml` and `docker-compose.production.yml` to ensure the application server restarts on failure. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R12) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R16)
* Applied `restart: unless-stopped` to the `postgres` service in both configuration files for improved database availability. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R26) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R33)
* Set `restart: unless-stopped` for the `pgbouncer` service in both files, improving connection pooling reliability. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R38) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R45)
* Enabled `restart: unless-stopped` for the `redis` service in both files, ensuring the cache service remains available. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R55) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R62)
* Added `restart: unless-stopped` to the `nginx` service in both files to maintain reverse proxy uptime. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R79) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R89)