### PR TITLE
Optimize memory limits and concurrency for Django and Celery services

### DIFF
--- a/compose/production/django/celery/worker/start
+++ b/compose/production/django/celery/worker/start
@@ -5,4 +5,4 @@ set -o pipefail
 set -o nounset
 
 
-exec celery -A config.celery_app worker -l INFO
+exec celery -A config.celery_app worker -l INFO --pool=threads --concurrency=6

--- a/compose/production/django/start
+++ b/compose/production/django/start
@@ -7,4 +7,4 @@ set -o nounset
 
 python /app/manage.py collectstatic --noinput
 
-exec /usr/local/bin/gunicorn config.asgi:application --bind 0.0.0.0:5000 --chdir=/app -k uvicorn_worker.UvicornWorker --workers 4
+exec /usr/local/bin/gunicorn config.asgi:application --bind 0.0.0.0:5000 --chdir=/app -k uvicorn_worker.UvicornWorker --workers 2 --max-requests 1000 --max-requests-jitter 50 --worker-tmp-dir /dev/shm

--- a/config/settings/base.py
+++ b/config/settings/base.py
@@ -328,6 +328,8 @@ CELERY_WORKER_SEND_TASK_EVENTS = True
 CELERY_TASK_SEND_SENT_EVENT = True
 # https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-hijack-root-logger
 CELERY_WORKER_HIJACK_ROOT_LOGGER = False
+# https://docs.celeryq.dev/en/stable/userguide/configuration.html#worker-prefetch-multiplier
+CELERY_WORKER_PREFETCH_MULTIPLIER = 1
 CELERY_RESULT_BACKEND = "django-db"
 CELERY_CACHE_BACKEND = "django-cache"
 

--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -10,7 +10,7 @@ services:
   django: &django
     image: ghcr.io/instarchiver/instarchiver-backend/django:latest
     restart: unless-stopped
-    mem_limit: 1g
+    mem_limit: 512m
     volumes:
       - instarchiver_production_django_media:/app/core/media
     depends_on:
@@ -62,6 +62,7 @@ services:
   celeryworker:
     <<: *django
     image: ghcr.io/instarchiver/instarchiver-backend/django:latest
+    mem_limit: 384m
     command: /start-celeryworker
 
   celerybeat:
@@ -72,6 +73,7 @@ services:
   flower:
     <<: *django
     image: ghcr.io/instarchiver/instarchiver-backend/django:latest
+    mem_limit: 256m
     command: /start-flower
 
   nginx:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -14,7 +14,7 @@ services:
 
     image: instarchiver_production_django
     restart: unless-stopped
-    mem_limit: 1g
+    mem_limit: 512m
     volumes:
       - instarchiver_production_django_media:/app/core/media
     depends_on:
@@ -69,6 +69,7 @@ services:
   celeryworker:
     <<: *django
     image: instarchiver_production_celeryworker
+    mem_limit: 384m
     command: /start-celeryworker
 
   celerybeat:
@@ -79,6 +80,7 @@ services:
   flower:
     <<: *django
     image: instarchiver_production_flower
+    mem_limit: 256m
     command: /start-flower
 
   nginx:


### PR DESCRIPTION
## Description

This pull request introduces several resource optimization changes to the Django, Celery worker, and Flower services, as well as some Celery configuration improvements. The main focus is on reducing memory usage in the Docker Compose configurations and fine-tuning worker process behavior for better performance and reliability.

**Resource and Memory Optimization:**

* Reduced the `mem_limit` for the `django` service from 1GB to 512MB in both `docker-compose.ghcr.yml` and `docker-compose.production.yml` to lower memory usage. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0L13-R13) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8L17-R17)
* Added or adjusted `mem_limit` for the `celeryworker` (384MB) and `flower` (256MB) services in both Docker Compose files to further control resource allocation. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R65) [[2]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R76) [[3]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R72) [[4]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R83)

**Celery and Gunicorn Worker Configuration:**

* Changed the Celery worker startup command to use the `threads` pool with a concurrency of 6, which can improve task processing efficiency under memory constraints.
* Set `CELERY_WORKER_PREFETCH_MULTIPLIER = 1` in `config/settings/base.py` to reduce task prefetching and lower memory footprint per worker.

**Gunicorn Process Management:**

* Reduced Gunicorn worker count from 4 to 2 and added `--max-requests` and `--max-requests-jitter` to recycle workers after a set number of requests, helping to prevent memory leaks and improve stability. Also set `--worker-tmp-dir /dev/shm` for faster temporary file access.