### PR TITLE
Enhance static file handling with S3 and middleware updates

### DIFF
--- a/config/settings/production.py
+++ b/config/settings/production.py
@@ -10,6 +10,7 @@ from sentry_sdk.integrations.redis import RedisIntegration
 from .base import *  # noqa: F403
 from .base import DATABASES
 from .base import INSTALLED_APPS
+from .base import MIDDLEWARE
 from .base import REDIS_URL
 from .base import SPECTACULAR_SETTINGS
 from .base import env
@@ -97,25 +98,43 @@ AWS_S3_SIGNATURE_VERSION = "s3v4"
 
 # STATIC & MEDIA
 # ------------------------
+AWS_S3_CONFIGURED = all(
+    (
+        AWS_STORAGE_BUCKET_NAME,
+        AWS_S3_ENDPOINT_URL,
+        AWS_S3_ACCESS_KEY_ID,
+        AWS_S3_SECRET_ACCESS_KEY,
+    ),
+)
+
 STORAGES = {
     "default": {
         "BACKEND": (
             "storages.backends.s3boto3.S3Boto3Storage"
-            if all(
-                (
-                    AWS_STORAGE_BUCKET_NAME,
-                    AWS_S3_ENDPOINT_URL,
-                    AWS_S3_ACCESS_KEY_ID,
-                    AWS_S3_SECRET_ACCESS_KEY,
-                ),
-            )
+            if AWS_S3_CONFIGURED
             else "django.core.files.storage.FileSystemStorage"
         ),
     },
-    "staticfiles": {
-        "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
-    },
+    "staticfiles": (
+        {
+            "BACKEND": "storages.backends.s3boto3.S3ManifestStaticStorage",
+            "OPTIONS": {
+                "location": "static",
+            },
+        }
+        if AWS_S3_CONFIGURED
+        else {
+            "BACKEND": "whitenoise.storage.CompressedManifestStaticFilesStorage",
+        }
+    ),
 }
+
+if AWS_S3_CONFIGURED:
+    # Static files are served directly from S3/R2, so Whitenoise's middleware
+    # never gets hit and is just dead weight in the request path.
+    MIDDLEWARE = [
+        m for m in MIDDLEWARE if m != "whitenoise.middleware.WhiteNoiseMiddleware"
+    ]
 
 # EMAIL
 # ------------------------------------------------------------------------------


### PR DESCRIPTION
## Description

This pull request updates the production settings to improve how static and media file storage is configured, especially regarding AWS S3 integration. The changes make the selection of storage backends more dynamic based on whether AWS S3 is properly configured, and they optimize middleware usage when serving static files from S3.

**Storage backend configuration improvements:**

* The `STORAGES` setting now dynamically selects between S3 and local storage backends for both default and static files, based on the new `AWS_S3_CONFIGURED` flag. This ensures that S3 is only used if all required credentials are present.
* When S3 is configured, static files use `storages.backends.s3boto3.S3ManifestStaticStorage` with a specified location, otherwise they fall back to `whitenoise.storage.CompressedManifestStaticFilesStorage`.

**Middleware optimization:**

* If S3 is used for static files, the `WhiteNoiseMiddleware` is removed from the `MIDDLEWARE` list, since it is unnecessary and would otherwise add overhead.
* The `MIDDLEWARE` variable is now explicitly imported from `.base` to enable this dynamic modification.