### PR TITLE
Add collectstatic service to Docker Compose with CLI profile

### DIFF
--- a/docker-compose.ghcr.yml
+++ b/docker-compose.ghcr.yml
@@ -87,6 +87,8 @@ services:
 
   collectstatic:
     <<: *django
+    restart: "no"
+    profiles: ["cli"]
     command: python manage.py collectstatic --noinput
 
   awscli:

--- a/docker-compose.production.yml
+++ b/docker-compose.production.yml
@@ -97,6 +97,8 @@ services:
 
   collectstatic:
     <<: *django
+    restart: "no"
+    profiles: ["cli"]
     command: python manage.py collectstatic --noinput
 
   awscli:


### PR DESCRIPTION
## Description

This pull request updates the configuration for the `collectstatic` service in both `docker-compose.ghcr.yml` and `docker-compose.production.yml`. The main changes are to improve how the service is managed and when it is run.

**Docker Compose configuration improvements:**

* Added `restart: "no"` to the `collectstatic` service to prevent it from automatically restarting after completion, which is appropriate since this is a one-off command. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R90-R91) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R100-R101)
* Added `profiles: ["cli"]` to the `collectstatic` service to ensure it only runs when explicitly requested as part of the CLI profile, reducing the risk of it running unintentionally during normal service startup. [[1]](diffhunk://#diff-853304662c013625dcbd238912cdcc9d9d42985f4e95924ae7fcc81fe43c83c0R90-R91) [[2]](diffhunk://#diff-939173f100b9faaec94fb740138ad0f6376d79e4317974d4dc28a5b489bab7b8R100-R101)